### PR TITLE
fix/align/clarify domain language

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Implementation of a DKG"
 documentation = ""
-edition = "2018"
+edition = "2020"
 exclude = [""]
 homepage = "https://maidsafe.net"
 license = "GPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+authors = ["MaidSafe Developers <dev@maidsafe.net>"]
+description = "Implementation of a DKG"
+documentation = ""
+edition = "2018"
+exclude = [""]
+homepage = "https://maidsafe.net"
+license = "GPL-3.0"
+name = "bls_dkg"
+readme = "README.md"
+repository = "https://github.com/maidsafe/BLS-DKG"
+version = "0.1.0"
+
+[dependencies]
+fnv = "~1.0.6"
+itertools = "~0.8.0"
+lazy_static = "~1.2.0"
+log = "~0.3.8"
+maidsafe_utilities = "~0.18.0"
+pom = { version = "~1.1.0", optional = true }
+proptest = { version = "~0.8.6", optional = true }
+rand = "~0.4.2"
+rand_core = "0.2.1"
+serde = "~1.0.66"
+serde_derive = "~1.0.66"
+tiny-keccak = "~1.5.0"
+unwrap = "~1.2.1"
+threshold_crypto = "~0.3.1"
+failure = "~0.1.5"
+
+[dev-dependencies]
+clap = "~2.32.0"
+criterion = "~0.2.5"
+pom = "~1.1.0"
+walkdir = "~2.2.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Implementation of a DKG"
 documentation = ""
-edition = "2020"
+edition = "2018"
 exclude = [""]
 homepage = "https://maidsafe.net"
 license = "GPL-3.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+use_try_shorthand = true

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,71 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::{fmt::Debug, hash::Hash};
+
+/// The public identity of a node.  It provides functionality to allow it to be used as an
+/// asymmetric signing public key.
+pub trait PublicId: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Debug {
+    /// The signature type associated with the chosen asymmetric key scheme.
+    type Signature: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned + Debug;
+    /// Verifies `signature` against `data` using this `PublicId`.  Returns `true` if valid.
+    fn verify_signature(&self, signature: &Self::Signature, data: &[u8]) -> bool;
+}
+
+/// The secret identity of a node.  It provides functionality to allow it to be used as an
+/// asymmetric signing secret key and to also yield the associated public identity.
+pub trait SecretId {
+    /// The associated public identity type.
+    type PublicId: PublicId;
+
+    /// Returns the associated public identity.
+    fn public_id(&self) -> &Self::PublicId;
+
+    /// Creates a detached `Signature` of `data`.
+    fn sign_detached(&self, data: &[u8]) -> <Self::PublicId as PublicId>::Signature;
+
+    /// Creates a `Proof` of `data`.
+    fn create_proof(&self, data: &[u8]) -> Proof<Self::PublicId> {
+        Proof {
+            public_id: self.public_id().clone(),
+            signature: self.sign_detached(data),
+        }
+    }
+
+    /// Encrypts the message using own Rng to `to`
+    fn encrypt<M: AsRef<[u8]>>(&self, to: &Self::PublicId, msg: M) -> Option<Vec<u8>>;
+    /// Decrypt message from `from`.
+    fn decrypt(&self, from: &Self::PublicId, ct: &[u8]) -> Option<Vec<u8>>;
+}
+
+/// A basic helper to carry a given [`Signature`](trait.PublicId.html#associatedtype.Signature)
+/// along with the signer's [`PublicId`](trait.PublicId.html).
+#[serde(bound = "")]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Proof<P: PublicId> {
+    pub(super) public_id: P,
+    pub(super) signature: P::Signature,
+}
+
+impl<P: PublicId> Proof<P> {
+    /// Returns the associated public identity.
+    pub fn public_id(&self) -> &P {
+        &self.public_id
+    }
+
+    /// Returns the associated signature.
+    pub fn signature(&self) -> &P::Signature {
+        &self.signature
+    }
+
+    /// Verifies this `Proof` against `data`.  Returns `true` if valid.
+    pub fn is_valid(&self, data: &[u8]) -> bool {
+        self.public_id.verify_signature(&self.signature, data)
+    }
+}

--- a/src/key_gen/dkg_result.rs
+++ b/src/key_gen/dkg_result.rs
@@ -1,0 +1,39 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use std::fmt::{self, Debug, Formatter};
+use threshold_crypto::{PublicKeySet, SecretKeyShare};
+
+#[derive(Clone)]
+/// DKG result
+pub struct DkgResult {
+    /// Public key set to verify threshold signatures
+    pub public_key_set: PublicKeySet,
+    /// Secret Key share.
+    pub secret_key_share: SecretKeyShare,
+}
+
+impl DkgResult {
+    /// Create DkgResult from components
+    pub fn new(public_key_set: PublicKeySet, secret_key_share: SecretKeyShare) -> Self {
+        Self {
+            public_key_set,
+            secret_key_share,
+        }
+    }
+}
+
+impl Debug for DkgResult {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "DkgResult({:?}, {:?})",
+            self.public_key_set, self.secret_key_share
+        )
+    }
+}

--- a/src/key_gen/dkg_result.rs
+++ b/src/key_gen/dkg_result.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 MaidSafe.net limited.
+// Copyright 2020 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/key_gen/message.rs
+++ b/src/key_gen/message.rs
@@ -27,6 +27,7 @@ pub enum DkgMessage<P: PublicId> {
     },
     Complain {
         key_gen_id: u64,
+        target: u64,
         msg: Vec<u8>,
     },
     Justification {

--- a/src/key_gen/message.rs
+++ b/src/key_gen/message.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Commit, Part};
+use super::{Commitment, Part};
 use crate::id::PublicId;
 use std::collections::BTreeSet;
 use std::fmt;
@@ -15,7 +15,7 @@ use std::fmt;
 #[serde(bound = "")]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum DkgMessage<P: PublicId> {
-    Initial {
+    Initialization {
         key_gen_id: u64,
         m: usize,
         n: usize,
@@ -25,7 +25,7 @@ pub enum DkgMessage<P: PublicId> {
         key_gen_id: u64,
         part: Part,
     },
-    Complain {
+    Complaint {
         key_gen_id: u64,
         target: u64,
         msg: Vec<u8>,
@@ -36,21 +36,21 @@ pub enum DkgMessage<P: PublicId> {
     },
     Commitment {
         key_gen_id: u64,
-        commit: Commit,
+        commitment: Commitment,
     },
 }
 
 impl<P: PublicId> fmt::Debug for DkgMessage<P> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DkgMessage::Initial { key_gen_id, .. } => {
-                write!(formatter, "DkgInitial({})", key_gen_id)
+            DkgMessage::Initialization { key_gen_id, .. } => {
+                write!(formatter, "DkgInitialization({})", key_gen_id)
             }
             DkgMessage::Contribution { key_gen_id, .. } => {
                 write!(formatter, "DkgContribution({})", key_gen_id)
             }
-            DkgMessage::Complain { key_gen_id, .. } => {
-                write!(formatter, "DkgComplain({})", key_gen_id)
+            DkgMessage::Complaint { key_gen_id, .. } => {
+                write!(formatter, "DkgComplaint({})", key_gen_id)
             }
             DkgMessage::Justification { key_gen_id, .. } => {
                 write!(formatter, "DkgJustification({})", key_gen_id)

--- a/src/key_gen/message.rs
+++ b/src/key_gen/message.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::{Commit, Part};
+use crate::id::PublicId;
+use std::collections::BTreeSet;
+use std::fmt;
+
+/// Messages used for running BLS DKG.
+#[serde(bound = "")]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum DkgMessage<P: PublicId> {
+    Initial {
+        key_gen_id: u64,
+        m: usize,
+        n: usize,
+        member_list: BTreeSet<P>,
+    },
+    Contribution {
+        key_gen_id: u64,
+        part: Part,
+    },
+    Complain {
+        key_gen_id: u64,
+        msg: Vec<u8>,
+    },
+    Justification {
+        key_gen_id: u64,
+        part: Part,
+    },
+    Commitment {
+        key_gen_id: u64,
+        commit: Commit,
+    },
+}
+
+impl<P: PublicId> fmt::Debug for DkgMessage<P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DkgMessage::Initial { key_gen_id, .. } => {
+                write!(formatter, "DkgInitial({})", key_gen_id)
+            }
+            DkgMessage::Contribution { key_gen_id, .. } => {
+                write!(formatter, "DkgContribution({})", key_gen_id)
+            }
+            DkgMessage::Complain { key_gen_id, .. } => {
+                write!(formatter, "DkgComplain({})", key_gen_id)
+            }
+            DkgMessage::Justification { key_gen_id, .. } => {
+                write!(formatter, "DkgJustification({})", key_gen_id)
+            }
+            DkgMessage::Commitment { key_gen_id, .. } => {
+                write!(formatter, "DkgCommitment({})", key_gen_id)
+            }
+        }
+    }
+}

--- a/src/key_gen/mod.rs
+++ b/src/key_gen/mod.rs
@@ -1,0 +1,532 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+pub mod dkg_result;
+pub mod message;
+mod rng_adapter;
+
+use crate::id::{PublicId, SecretId};
+use crate::key_gen::message::DkgMessage;
+use dkg_result::DkgResult;
+use failure::Fail;
+use maidsafe_utilities::serialisation;
+use rand;
+use serde_derive::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{self, Debug, Formatter};
+use threshold_crypto::pairing::{CurveAffine, Field};
+use threshold_crypto::{
+    poly::{BivarCommitment, BivarPoly, Poly},
+    serde_impl::FieldWrap,
+    Fr, G1Affine, SecretKeyShare,
+};
+
+/// A local error while handling a message, that was not caused by that message being invalid.
+#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+pub enum Error {
+    /// Unknown key set.
+    #[fail(display = "Unknown")]
+    Unknown,
+    /// Unknown sender.
+    #[fail(display = "Unknown sender")]
+    UnknownSender,
+    /// Failed to serialize message.
+    #[fail(display = "Serialization error: {}", _0)]
+    Serialization(String),
+    /// Failed to encrypt message.
+    #[fail(display = "Encryption error")]
+    Encryption,
+}
+
+impl From<serialisation::SerialisationError> for Error {
+    fn from(err: serialisation::SerialisationError) -> Error {
+        Error::Serialization(format!("{:?}", err))
+    }
+}
+
+/// A contribution by a node for the key generation. It must to be sent to all participating
+/// nodes and handled by all of them, including the one that produced it.
+#[derive(Deserialize, Serialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Part(BivarCommitment, Vec<Vec<u8>>);
+
+impl Debug for Part {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Part")
+            .field(&format!("<degree {}>", self.0.degree()))
+            .field(&format!("<{} rows>", self.1.len()))
+            .finish()
+    }
+}
+
+/// A confirmation that we have received and verified a validator's part. It must be sent to
+/// all participating nodes and handled by all of them, including ourselves.
+///
+/// The message is only produced after we verified our row against the commitment in the `Part`.
+/// For each node, it contains one encrypted value of that row.
+#[derive(Deserialize, Serialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Commit(u64, Vec<Vec<u8>>);
+
+impl Debug for Commit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Commit")
+            .field(&self.0)
+            .field(&format!("<{} values>", self.1.len()))
+            .finish()
+    }
+}
+
+/// The information needed to track a single proposer's secret sharing process.
+#[derive(Debug, PartialEq, Eq)]
+struct ProposalState {
+    /// The proposer's commitment.
+    commit: BivarCommitment,
+    /// The verified values we received from `Commit` messages.
+    values: BTreeMap<u64, Fr>,
+    /// The nodes which have commited.
+    commits: BTreeSet<u64>,
+}
+
+impl ProposalState {
+    /// Creates a new part state with a commitment.
+    fn new(commit: BivarCommitment) -> ProposalState {
+        ProposalState {
+            commit,
+            values: BTreeMap::new(),
+            commits: BTreeSet::new(),
+        }
+    }
+
+    /// Returns `true` if at least `2 * threshold + 1` nodes have commited.
+    fn is_complete(&self, threshold: usize) -> bool {
+        self.commits.len() > 2 * threshold
+    }
+}
+
+impl<'a> serde::Deserialize<'a> for ProposalState {
+    fn deserialize<D: serde::Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
+        let (commit, values, commits) = serde::Deserialize::deserialize(deserializer)?;
+        let values: Vec<(u64, FieldWrap<Fr>)> = values;
+        Ok(Self {
+            commit,
+            values: values.into_iter().map(|(idx, fr)| (idx, fr.0)).collect(),
+            commits,
+        })
+    }
+}
+
+/// The outcome of handling and verifying a `Part` message.
+pub enum PartOutcome {
+    /// The message was valid: the part of it that was encrypted to us matched the public
+    /// commitment, so we can multicast an `Commit` message for it. If we have already handled the
+    /// same `Part` before, this contains `None` instead.
+    Valid(Option<Commit>),
+    /// The message was invalid: We now know that the proposer is faulty.
+    Invalid(PartFault),
+}
+
+/// The outcome of handling and verifying a `Commit` message.
+pub enum CommitOutcome {
+    /// The message was valid.
+    Valid,
+    /// The message was invalid: The sender is faulty.
+    Invalid(CommitFault),
+}
+
+#[derive(Deserialize, PartialEq)]
+pub enum DkgPhases {
+    Initial,
+    Contribute,
+    Complain,
+    Justification,
+    Commitment,
+    Finalize,
+}
+
+#[derive(Default)]
+struct AccumulateInitial<P: PublicId> {
+    senders: BTreeSet<u64>,
+    received_initializes: BTreeMap<(usize, usize, BTreeSet<P>), usize>,
+}
+
+impl<P: PublicId> AccumulateInitial<P> {
+    fn new() -> AccumulateInitial<P> {
+        AccumulateInitial {
+            senders: BTreeSet::new(),
+            received_initializes: BTreeMap::new(),
+        }
+    }
+
+    fn add_initial(&mut self, dkg_msg: DkgMessage<P>) -> Option<(usize, usize, BTreeSet<P>)> {
+        let (sender, m, n, member_list) = if let DkgMessage::Initial {
+            key_gen_id,
+            m,
+            n,
+            member_list,
+        } = dkg_msg
+        {
+            (key_gen_id, m, n, member_list)
+        } else {
+            return None;
+        };
+
+        if self.senders.insert(sender) {
+            return None;
+        }
+
+        let paras = (m, n, member_list);
+        if let Some(value) = self.received_initializes.get_mut(&paras) {
+            *value += 1;
+            if *value > (2 * m + 1) {
+                return Some(paras);
+            }
+        } else {
+            let _ = self.received_initializes.insert(paras, 1);
+        }
+        None
+    }
+}
+
+/// A synchronous algorithm for dealerless distributed key generation.
+///
+/// It requires that all nodes handle all messages in the exact same order.
+pub struct KeyGen<S: SecretId> {
+    /// Our node ID.
+    our_id: S::PublicId,
+    /// Our node index.
+    our_idx: u64,
+    /// The public keys of all nodes, by node ID.
+    pub_keys: BTreeSet<S::PublicId>,
+    /// Proposed bivariate polynomials.
+    parts: BTreeMap<u64, ProposalState>,
+    /// The degree of the generated polynomial.
+    threshold: usize,
+    /// Current DKG phase.
+    dkg_phase: DkgPhases,
+    /// Accumulates initializations.
+    acc_initial: AccumulateInitial<S::PublicId>,
+}
+
+impl<S: SecretId> KeyGen<S> {
+    /// Creates a new `KeyGen` instance, together with the `Initial` message that should be
+    /// multicast to all nodes.
+    pub fn initialize(
+        sec_key: &S,
+        threshold: usize,
+        pub_keys: BTreeSet<S::PublicId>,
+    ) -> Result<(KeyGen<S>, DkgMessage<S::PublicId>), Error> {
+        let our_id = sec_key.public_id().clone();
+        let our_idx = if let Some(idx) = pub_keys.iter().position(|id| *id == our_id) {
+            idx as u64
+        } else {
+            return Err(Error::Unknown);
+        };
+
+        let key_gen = KeyGen::<S> {
+            our_id,
+            our_idx,
+            pub_keys: pub_keys.clone(),
+            parts: BTreeMap::new(),
+            threshold,
+            dkg_phase: DkgPhases::Initial,
+            acc_initial: AccumulateInitial::new(),
+        };
+
+        Ok((
+            key_gen,
+            DkgMessage::Initial {
+                key_gen_id: our_idx,
+                m: threshold,
+                n: pub_keys.len(),
+                member_list: pub_keys,
+            },
+        ))
+    }
+
+    /// Handles an incoming initialize message. Creates the `Contribute` message once quorumn
+    /// agreement reached, and the message should be multicast to all nodes.
+    pub fn handle_initialize(
+        &mut self,
+        sec_key: &S,
+        rng: &mut dyn rand::Rng,
+        dkg_msg: DkgMessage<S::PublicId>,
+    ) -> Result<Option<DkgMessage<S::PublicId>>, Error> {
+        if self.dkg_phase != DkgPhases::Initial {
+            return Err(Error::Unknown);
+        }
+        if let Some((m, n, member_list)) = self.acc_initial.add_initial(dkg_msg) {
+            self.threshold = m;
+            self.pub_keys = member_list;
+            self.dkg_phase = DkgPhases::Contribute;
+
+            let mut rng = rng_adapter::RngAdapter(&mut *rng);
+            let our_part = BivarPoly::random(self.threshold, &mut rng);
+            let commit = our_part.commitment();
+            let encrypt = |(i, pk): (usize, &S::PublicId)| {
+                let row = our_part.row(i + 1);
+                sec_key
+                    .encrypt(pk, &serialisation::serialise(&row)?)
+                    .ok_or(Error::Encryption)
+            };
+            let rows = self
+                .pub_keys
+                .iter()
+                .enumerate()
+                .map(encrypt)
+                .collect::<Result<Vec<_>, Error>>()?;
+            return Ok(Some(DkgMessage::Contribution {
+                key_gen_id: self.our_idx,
+                part: Part(commit, rows),
+            }));
+        }
+        Ok(None)
+    }
+
+    /// Handles a `Contribute` message.
+    /// If it is invalid, returns a `Complain` message to be broadcast.
+    /// If all contributed, retuns a `Commitment` message to be broadcast.
+    pub fn handle_contribute(
+        &mut self,
+        sec_key: &S,
+        dkg_msg: DkgMessage<S::PublicId>,
+    ) -> Result<Option<DkgMessage<S::PublicId>>, Error> {
+        if self.dkg_phase != DkgPhases::Contribute {
+            return Err(Error::Unknown);
+        }
+        let (sender_idx, part) =
+            if let DkgMessage::Contribution { key_gen_id, part } = dkg_msg.clone() {
+                (key_gen_id, part)
+            } else {
+                return Err(Error::Unknown);
+            };
+
+        let sender_id = self
+            .node_id_from_index(sender_idx)
+            .ok_or(Error::UnknownSender)?;
+        let row = match self.handle_part_or_fault(sec_key, sender_idx, &sender_id, part) {
+            Ok(Some(row)) => row,
+            Ok(None) => return Ok(None),
+            Err(_fault) => {
+                let invalid_contribute = serialisation::serialise(&dkg_msg)?;
+                return Ok(Some(DkgMessage::Complain {
+                    key_gen_id: self.our_idx,
+                    msg: invalid_contribute,
+                }));
+            }
+        };
+        // The row is valid. Encrypt one value for each node and broadcast a `Commitment`.
+        let mut values = Vec::new();
+        for (idx, pk) in self.pub_keys.iter().enumerate() {
+            let val = row.evaluate(idx + 1);
+            let ser_val = serialisation::serialise(&FieldWrap(val))?;
+            values.push(sec_key.encrypt(pk, ser_val).ok_or(Error::Encryption)?);
+        }
+        self.dkg_phase = DkgPhases::Commitment;
+        Ok(Some(DkgMessage::Commitment {
+            key_gen_id: self.our_idx,
+            commit: Commit(sender_idx, values),
+        }))
+    }
+
+    /// Handles a `Commit` message.
+    pub fn handle_commit(
+        &mut self,
+        sec_key: &S,
+        dkg_msg: DkgMessage<S::PublicId>,
+    ) -> Result<CommitOutcome, Error> {
+        if self.dkg_phase != DkgPhases::Commitment {
+            return Err(Error::Unknown);
+        }
+        let (sender_idx, commit) = if let DkgMessage::Commitment { key_gen_id, commit } = dkg_msg {
+            (key_gen_id, commit)
+        } else {
+            return Err(Error::Unknown);
+        };
+        let sender_id = self
+            .node_id_from_index(sender_idx)
+            .ok_or(Error::UnknownSender)?;
+
+        Ok(
+            match self.handle_commit_or_fault(sec_key, &sender_id, sender_idx, commit) {
+                Ok(()) => {
+                    if self.is_ready() {
+                        self.dkg_phase = DkgPhases::Finalize;
+                    }
+                    CommitOutcome::Valid
+                }
+                Err(fault) => CommitOutcome::Invalid(fault),
+            },
+        )
+    }
+
+    /// Returns the index of the node, or `None` if it is unknown.
+    fn node_index(&self, node_id: &S::PublicId) -> Option<u64> {
+        self.pub_keys
+            .iter()
+            .position(|id| id == node_id)
+            .map(|idx| idx as u64)
+    }
+
+    /// Returns the id of the index, or `None` if it is unknown.
+    fn node_id_from_index(&self, node_idx: u64) -> Option<S::PublicId> {
+        for (i, pk) in self.pub_keys.iter().enumerate() {
+            if i == node_idx as usize {
+                return Some(pk.clone());
+            }
+        }
+        None
+    }
+
+    /// Returns the number of complete parts. If this is at least `threshold + 1`, the keys can
+    /// be generated, but it is possible to wait for more to increase security.
+    fn count_complete(&self) -> usize {
+        self.parts
+            .values()
+            .filter(|part| part.is_complete(self.threshold))
+            .count()
+    }
+
+    /// Returns `true` if enough parts are complete to safely generate the new key.
+    fn is_ready(&self) -> bool {
+        self.count_complete() > self.threshold
+    }
+
+    /// Returns the new secret key share and the public key set.
+    pub fn generate(&self) -> Result<(BTreeSet<S::PublicId>, DkgResult), Error> {
+        if self.dkg_phase != DkgPhases::Finalize {
+            return Err(Error::Unknown);
+        }
+
+        let mut pk_commit = Poly::zero().commitment();
+        let mut sk_val = Fr::zero();
+        let is_complete = |part: &&ProposalState| part.is_complete(self.threshold);
+        for part in self.parts.values().filter(is_complete) {
+            pk_commit += part.commit.row(0);
+            let row = Poly::interpolate(part.values.iter().take(self.threshold + 1));
+            sk_val.add_assign(&row.evaluate(0));
+        }
+        let sk = SecretKeyShare::from_mut(&mut sk_val);
+        Ok((self.pub_keys.clone(), DkgResult::new(pk_commit.into(), sk)))
+    }
+
+    /// Handles a `Part`, returns a `PartFault` if it is invalid.
+    fn handle_part_or_fault(
+        &mut self,
+        sec_key: &S,
+        sender_idx: u64,
+        sender_id: &S::PublicId,
+        Part(commit, rows): Part,
+    ) -> Result<Option<Poly>, PartFault> {
+        if rows.len() != self.pub_keys.len() {
+            return Err(PartFault::RowCount);
+        }
+        if let Some(state) = self.parts.get(&sender_idx) {
+            if state.commit != commit {
+                return Err(PartFault::MultipleParts);
+            }
+            return Ok(None); // We already handled this `Part` before.
+        }
+        let commit_row = commit.row(self.our_idx + 1);
+        // Retrieve our own row's commitment, and store the full commitment.
+        let _ = self.parts.insert(sender_idx, ProposalState::new(commit));
+        // We are a validator: Decrypt and deserialize our row and compare it to the commitment.
+        let ser_row = sec_key
+            .decrypt(sender_id, &rows[self.our_idx as usize])
+            .ok_or(PartFault::DecryptRow)?;
+        let row: Poly =
+            serialisation::deserialise(&ser_row).map_err(|_| PartFault::DeserializeRow)?;
+        if row.commitment() != commit_row {
+            return Err(PartFault::RowCommitment);
+        }
+        Ok(Some(row))
+    }
+
+    /// Handles a `Commit` message.
+    fn handle_commit_or_fault(
+        &mut self,
+        sec_key: &S,
+        sender_id: &S::PublicId,
+        sender_idx: u64,
+        Commit(proposer_idx, values): Commit,
+    ) -> Result<(), CommitFault> {
+        if values.len() != self.pub_keys.len() {
+            return Err(CommitFault::ValueCount);
+        }
+        let part = self
+            .parts
+            .get_mut(&proposer_idx)
+            .ok_or(CommitFault::MissingPart)?;
+        if !part.commits.insert(sender_idx) {
+            return Ok(()); // We already handled this `Commit` before.
+        }
+        let our_idx = self.our_idx;
+        // We are a validator: Decrypt and deserialize our value and compare it to the commitment.
+        let ser_val = sec_key
+            .decrypt(sender_id, &values[our_idx as usize])
+            .ok_or(CommitFault::DecryptValue)?;
+        let val = serialisation::deserialise::<FieldWrap<Fr>>(&ser_val)
+            .map_err(|_| CommitFault::DeserializeValue)?
+            .into_inner();
+        if part.commit.evaluate(our_idx + 1, sender_idx + 1) != G1Affine::one().mul(val) {
+            return Err(CommitFault::ValueCommitment);
+        }
+        let _ = part.values.insert(sender_idx + 1, val);
+        Ok(())
+    }
+}
+
+// https://github.com/rust-lang/rust/issues/52560
+// Cannot derive Debug without changing the type parameter
+impl<S: SecretId> Debug for KeyGen<S> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "KeyGen{{our_id:{:?}, our_idx:{:?}, pub_keys :{:?}, parts:{:?}, threshold:{:?}}}",
+            self.our_id, self.our_idx, self.pub_keys, self.parts, self.threshold
+        )
+    }
+}
+
+/// `Commit` faulty entries.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Fail, Serialize, Deserialize, PartialOrd, Ord)]
+pub enum CommitFault {
+    /// The number of values differs from the number of nodes.
+    #[fail(display = "The number of values differs from the number of nodes")]
+    ValueCount,
+    /// No corresponding Part received.
+    #[fail(display = "No corresponding Part received")]
+    MissingPart,
+    /// Value decryption failed.
+    #[fail(display = "Value decryption failed")]
+    DecryptValue,
+    /// Value deserialization failed.
+    #[fail(display = "Value deserialization failed")]
+    DeserializeValue,
+    /// Value doesn't match the commitment.
+    #[fail(display = "Value doesn't match the commitment")]
+    ValueCommitment,
+}
+
+/// `Part` faulty entries.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Fail, Serialize, Deserialize, PartialOrd, Ord)]
+pub enum PartFault {
+    /// The number of rows differs from the number of nodes.
+    #[fail(display = "The number of rows differs from the number of nodes")]
+    RowCount,
+    /// Received multiple different Part messages from the same sender.
+    #[fail(display = "Received multiple different Part messages from the same sender")]
+    MultipleParts,
+    /// Could not decrypt our row in the Part message.
+    #[fail(display = "Could not decrypt our row in the Part message")]
+    DecryptRow,
+    /// Could not deserialize our row in the Part message.
+    #[fail(display = "Could not deserialize our row in the Part message")]
+    DeserializeRow,
+    /// Row does not match the commitment.
+    #[fail(display = "Row does not match the commitment")]
+    RowCommitment,
+}

--- a/src/key_gen/rng_adapter.rs
+++ b/src/key_gen/rng_adapter.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use rand::Rng;
+use rand_core::RngCore;
+
+pub(super) struct RngAdapter<'a, T: ?Sized>(pub &'a mut T);
+
+impl<'a, T> RngCore for RngAdapter<'a, T>
+where
+    T: Rng + ?Sized,
+{
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        self.0.fill_bytes(bytes);
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.0.fill_bytes(bytes);
+        Ok(())
+    }
+}

--- a/src/key_gen/rng_adapter.rs
+++ b/src/key_gen/rng_adapter.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 MaidSafe.net limited.
+// Copyright 2020 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
+    html_favicon_url = "https://maidsafe.net/img/favicon.ico",
+    test(attr(forbid(warnings)))
+)]
+#![allow(unused)]
+
+#[macro_use]
+extern crate serde_derive;
+
+mod id;
+mod key_gen;


### PR DESCRIPTION
fix/align/clarify domain language
- Fixes inconsistencies and typos.
- Aligns with original paper.
- Clarifies abbreviations and similar.